### PR TITLE
Implement map lighting

### DIFF
--- a/fix_render.sh
+++ b/fix_render.sh
@@ -1,1 +1,0 @@
-sed -i 's/\.clamp(0.0, 1.0)//g' src/render.rs

--- a/fix_render.sh
+++ b/fix_render.sh
@@ -1,0 +1,1 @@
+sed -i 's/\.clamp(0.0, 1.0)//g' src/render.rs

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,3 +1,4 @@
+mod light;
 mod map;
 mod sprite;
 mod tgam;
@@ -13,6 +14,7 @@ use bevy::image::Image;
 use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
 use byte::TryRead;
 use byte::ctx::LittleEndian;
+pub use light::{LightCell, LightDef, LightMap};
 pub use map::{Map, MapChunk, MapElementDetails, Rgba};
 pub use sprite::{Animation, Frame, Frames, MapSpriteDefinition, MapSpriteLibrary};
 pub use tgam::Tgam;

--- a/src/assets/light.rs
+++ b/src/assets/light.rs
@@ -1,0 +1,149 @@
+use std::collections::HashMap;
+use std::io::{Read, Seek};
+use std::sync::Arc;
+
+use byte::ctx::LittleEndian;
+use byte::{BytesExt, TryRead};
+
+use crate::assets::AssetError;
+
+pub struct LightDef {
+    pub ambiance_light: [f32; 3],
+    pub shadows: [f32; 3],
+    pub lights: [f32; 3],
+    pub allow_outdoor_lighting: bool,
+    pub has_shadows: bool,
+    pub night_light: [f32; 3],
+}
+
+impl LightDef {
+    pub const DEFAULT: LightDef = LightDef {
+        allow_outdoor_lighting: false,
+        ambiance_light: [1f32, 1f32, 1f32],
+        shadows: [1f32, 1f32, 1f32],
+        lights: [1f32, 1f32, 1f32],
+        has_shadows: false,
+        night_light: [0f32, 0f32, 0f32],
+    };
+}
+
+#[derive(Clone)]
+pub struct LightCell {
+    pub cell_x: i32,
+    pub cell_y: i32,
+    pub layer_colors: HashMap<i32, Arc<LightDef>>,
+}
+
+impl<'a> TryRead<'a, LittleEndian> for LightCell {
+    fn try_read(bytes: &'a [u8], ctx: LittleEndian) -> byte::Result<(Self, usize)> {
+        let offset = &mut 0;
+        let x = bytes.read::<i16>(offset, ctx)?;
+        let y = bytes.read::<i16>(offset, ctx)?;
+
+        let defcount = bytes.read::<u16>(offset, ctx)?;
+        let mut layer: Vec<Arc<LightDef>> = Vec::with_capacity(18 * 18);
+
+        for _ in 0..defcount {
+            let outdoor = bytes.read::<u8>(offset, ctx)? != 0;
+            let ambiance = bytes.read::<i32>(offset, ctx)?;
+            let shadow = bytes.read::<i32>(offset, ctx)?;
+            let light = bytes.read::<i32>(offset, ctx)?;
+            let night = [0f32, 0f32, 0f32];
+
+            let def = LightDef {
+                allow_outdoor_lighting: outdoor,
+                ambiance_light: [
+                    (ambiance & 0xFF) as f32 / 255f32 * 2f32,
+                    (ambiance >> 8 & 0xFF) as f32 / 255f32 * 2f32,
+                    (ambiance >> 16 & 0xFF) as f32 / 255f32 * 2f32,
+                ],
+                shadows: [
+                    (shadow & 0xFF) as f32 / 255f32,
+                    (shadow >> 8 & 0xFF) as f32 / 255f32,
+                    (shadow >> 16 & 0xFF) as f32 / 255f32,
+                ],
+                lights: [
+                    (light & 0xFF) as f32 / 255f32 - 0.5f32,
+                    (light >> 8 & 0xFF) as f32 / 255f32 - 0.5f32,
+                    (light >> 16 & 0xFF) as f32 / 255f32 - 0.5f32,
+                ],
+                has_shadows: shadow as u32 != 0xFF80_8080,
+                night_light: night,
+            };
+            layer.push(Arc::new(def));
+        }
+
+        let _layer_count = bytes.read::<i16>(offset, ctx)?;
+        let lcount = bytes.read::<i16>(offset, ctx)?;
+
+        let mut layer_colors = HashMap::new();
+        let default_layer = Arc::new(LightDef::DEFAULT);
+
+        for _ in 0..lcount {
+            let k = bytes.read::<u16>(offset, ctx)?;
+            let idx = bytes.read::<u16>(offset, ctx)?;
+            if (idx as usize) < layer.len() {
+                layer_colors.insert(k as i32, layer[idx as usize].clone());
+            } else {
+                layer_colors.insert(k as i32, default_layer.clone());
+            }
+        }
+
+        Ok((
+            LightCell {
+                cell_x: x as i32 * 18,
+                cell_y: y as i32 * 18,
+                layer_colors,
+            },
+            *offset,
+        ))
+    }
+}
+
+#[derive(Default)]
+pub struct LightMap {
+    pub light_maps: HashMap<i32, LightCell>,
+}
+
+impl LightMap {
+    pub fn load<R: Read + Seek>(input: R) -> Result<LightMap, AssetError> {
+        let mut archive = zip::ZipArchive::new(input)?;
+        let mut light_maps = HashMap::new();
+
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i)?;
+            if entry
+                .name()
+                .trim_matches(|c| char::is_numeric(c) || c == '-')
+                == "_"
+            {
+                let mut buffer = Vec::with_capacity(entry.size() as usize);
+                entry.read_to_end(&mut buffer)?;
+
+                let (cell, _) = LightCell::try_read(&buffer, LittleEndian)?;
+                let mapx = cell.cell_x / 18;
+                let mapy = cell.cell_y / 18;
+                let hash = mapx << 16 | (mapy & 0xFFFF);
+                light_maps.insert(hash, cell);
+            }
+        }
+        Ok(LightMap { light_maps })
+    }
+
+    pub fn get_color(&self, cell_x: i32, cell_y: i32, layer_idx: i32) -> Arc<LightDef> {
+        let map_x = (cell_x as f32 / 18f32).floor() as i32;
+        let map_y = (cell_y as f32 / 18f32).floor() as i32;
+        let key = map_x << 16 | map_y;
+
+        if let Some(cell) = self.light_maps.get(&key) {
+            let hash = (cell_x - cell.cell_x) + ((cell_y - cell.cell_y) + (layer_idx * 18)) * 18;
+            if let Some(color) = cell.layer_colors.get(&hash) {
+                color.clone()
+            } else {
+                Arc::new(LightDef::DEFAULT)
+            }
+        } else {
+            Arc::new(LightDef::DEFAULT)
+        }
+    }
+}

--- a/src/assets/map.rs
+++ b/src/assets/map.rs
@@ -189,6 +189,15 @@ pub struct Rgba {
 }
 
 impl Rgba {
+    pub fn new(r: f32, g: f32, b: f32, a: f32) -> Self {
+        Self {
+            r: ((r / 2. - 0.5) * 255.) as i8,
+            g: ((g / 2. - 0.5) * 255.) as i8,
+            b: ((b / 2. - 0.5) * 255.) as i8,
+            a: ((a / 2. - 0.5) * 255.) as i8,
+        }
+    }
+
     /// Converts the color to an array of 4 `f32` values.
     pub fn to_f32_array(self) -> [f32; 4] {
         [
@@ -291,6 +300,8 @@ impl<'a> MapElementDetails<'a> {
 
     /// Computes the hashcode used primarily for determining rendering depth order (z-sorting).
     /// It relies on cell coordinates (`x` and `y`) along with the element's `altitude_order`.
+    pub fn cell_x(&self) -> i32 { self.cell_x }
+    pub fn cell_y(&self) -> i32 { self.cell_y }
     pub fn hashcode(&self) -> i64 {
         (self.element.altitude_order as i64 & 0x1FFFi64) << 6i64
             | ((self.cell_x as i64 + 8192i64) & 0x3FFFi64) << 19i64
@@ -299,7 +310,7 @@ impl<'a> MapElementDetails<'a> {
 }
 
 /// Converts isometric coordinates `(x, y)` and `height` to screen coordinates.
-/// 
+///
 /// This transformation uses specific scaling factors:
 /// - A cell width of 86 units and cell height of 43 units.
 /// - An elevation unit multiplier of 10 for the `height` coordinate.

--- a/src/assets/map.rs
+++ b/src/assets/map.rs
@@ -301,7 +301,9 @@ impl<'a> MapElementDetails<'a> {
     /// Computes the hashcode used primarily for determining rendering depth order (z-sorting).
     /// It relies on cell coordinates (`x` and `y`) along with the element's `altitude_order`.
     pub fn cell_x(&self) -> i32 { self.cell_x }
+
     pub fn cell_y(&self) -> i32 { self.cell_y }
+    
     pub fn hashcode(&self) -> i64 {
         (self.element.altitude_order as i64 & 0x1FFFi64) << 6i64
             | ((self.cell_x as i64 + 8192i64) & 0x3FFFi64) << 19i64

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use anyhow::bail;
-use assets::{JarAssetSource, Map, MapSpriteLibrary, TgamLoader};
+use assets::{JarAssetSource, LightMap, Map, MapSpriteLibrary, TgamLoader};
 use bevy::asset::io::AssetSourceBuilder;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
@@ -73,10 +73,18 @@ fn main() -> anyhow::Result<()> {
 fn load_renderer(maps_path: &Path, map_id: i32) -> anyhow::Result<MapRenderer> {
     let map_path = maps_path.join("gfx").join(format!("{}.jar", map_id));
     let lib_path = maps_path.join("data.jar");
+    let light_path = maps_path.join("light").join(format!("{}.jar", map_id));
 
     let map = Map::load(File::open(map_path)?)?;
     let sprites = MapSpriteLibrary::load(File::open(lib_path)?)?;
-    Ok(MapRenderer::new(&map, &sprites))
+
+    let light_map = if light_path.exists() {
+        LightMap::load(File::open(light_path)?)?
+    } else {
+        LightMap::default()
+    };
+
+    Ok(MapRenderer::new(&map, &sprites, &light_map))
 }
 
 fn setup(mut commands: Commands<'_, '_>) {

--- a/src/render.rs
+++ b/src/render.rs
@@ -17,7 +17,7 @@ pub struct MapRenderer {
 }
 
 impl MapRenderer {
-    pub fn new(map: &Map, sprites: &MapSpriteLibrary) -> Self {
+    pub fn new(map: &Map, sprites: &MapSpriteLibrary, light_map: &crate::assets::LightMap) -> Self {
         let mut elements = map
             .chunks()
             .iter()
@@ -40,11 +40,22 @@ impl MapRenderer {
                 let (width, height) = def.size();
                 let (texture_width, texture_height) = def.texture_size();
 
+                let light_def = light_map.get_color(elem.cell_x(), elem.cell_y(), elem.group().layer() as i32);
+                let rgba: crate::assets::Rgba = elem.color().into();
+                let [r, g, b, a] = rgba.to_f32_array();
+                let color_tinted = crate::assets::Rgba::new(
+                    r * light_def.ambiance_light[0],
+                    g * light_def.ambiance_light[1],
+                    b * light_def.ambiance_light[2],
+                    a,
+                );
+
                 Renderable {
                     position: Vec3::new(x, y, z),
                     texture_size: UVec2::new(width.into(), height.into()),
                     render_size: UVec2::new(texture_width.into(), texture_height.into()),
                     color: elem.color().into(),
+                    color_tinted,
                     texture_id: def.texture_id(),
                     flip_x: def.flags().is_flip(),
                     animation: def.animation(),
@@ -69,6 +80,7 @@ struct Renderable {
     texture_size: UVec2,
     render_size: UVec2,
     color: Rgba,
+    color_tinted: Rgba,
     texture_id: i32,
     flip_x: bool,
     animation: Animation,
@@ -98,6 +110,7 @@ pub struct AnimationState {
     frames: Arc<Frames>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn rendering_system(
     mut commands: Commands<'_, '_>,
     assets: Res<'_, AssetServer>,
@@ -106,6 +119,7 @@ pub fn rendering_system(
     mut atlas_layouts: ResMut<'_, Assets<TextureAtlasLayout>>,
     mut render_state: ResMut<'_, MapRenderer>,
     settings: Res<'_, MapViewSettings>,
+    mut sprites: Query<'_, '_, &mut Sprite>,
 ) -> Result {
     let Ok(camera) = cameras.single() else {
         return Ok(());
@@ -131,9 +145,16 @@ pub fn rendering_system(
         }
 
         let entity = match elem.id {
-            Some(id) if commands.get_entity(id).is_ok() => id,
+            Some(id) if commands.get_entity(id).is_ok() => {
+                if let Ok(mut sprite) = sprites.get_mut(id) {
+                    let active_color = if settings.enable_light { elem.color_tinted } else { elem.color };
+                    let [r, g, b, a] = active_color.to_f32_array();
+                    sprite.color = Color::linear_rgba(r, g, b, a);
+                }
+                id
+            },
             _ => {
-                let entity = render(&mut commands, &assets, &mut atlas_layouts, elem);
+                let entity = render(&mut commands, &assets, &mut atlas_layouts, elem, settings.enable_light);
                 elem.id = Some(entity);
                 entity
             }
@@ -178,6 +199,7 @@ fn render(
     assets: &Res<'_, AssetServer>,
     atlas_layouts: &mut ResMut<'_, Assets<TextureAtlasLayout>>,
     renderable: &Renderable,
+    enable_light: bool,
 ) -> Entity {
     let img = assets.load::<Image>(format!("gfx://gfx/{}.tgam", renderable.texture_id));
 
@@ -203,7 +225,8 @@ fn render(
     let layout = atlas_layouts.add(layout);
 
     let mut sprite = Sprite::from_atlas_image(img, layout.into());
-    let [r, g, b, a] = renderable.color.to_f32_array();
+    let active_color = if enable_light { renderable.color_tinted } else { renderable.color };
+    let [r, g, b, a] = active_color.to_f32_array();
     sprite.color = Color::linear_rgba(r, g, b, a);
     sprite.flip_x = renderable.flip_x;
     sprite.custom_size = Some(renderable.render_size.as_vec2());

--- a/src/render.rs
+++ b/src/render.rs
@@ -41,9 +41,8 @@ impl MapRenderer {
                 let (texture_width, texture_height) = def.texture_size();
 
                 let light_def = light_map.get_color(elem.cell_x(), elem.cell_y(), elem.group().layer() as i32);
-                let rgba: crate::assets::Rgba = elem.color().into();
-                let [r, g, b, a] = rgba.to_f32_array();
-                let color_tinted = crate::assets::Rgba::new(
+                let [r, g, b, a] = Rgba::from(elem.color()).to_f32_array();
+                let color_tinted = Rgba::new(
                     r * light_def.ambiance_light[0],
                     g * light_def.ambiance_light[1],
                     b * light_def.ambiance_light[2],

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,12 +2,25 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::system::ResMut;
 use bevy_egui::{EguiContexts, egui};
 
-#[derive(Debug, Default, Resource)]
+#[derive(Debug, Resource)]
 pub struct MapViewSettings {
     pub layer_filter_on: bool,
     pub layer: u8,
     pub group_filter_on: bool,
     pub group: i32,
+    pub enable_light: bool,
+}
+
+impl Default for MapViewSettings {
+    fn default() -> Self {
+        Self {
+            layer_filter_on: false,
+            layer: 0,
+            group_filter_on: false,
+            group: 0,
+            enable_light: true,
+        }
+    }
 }
 
 pub fn settings_ui_system(
@@ -31,5 +44,6 @@ pub fn settings_ui_system(
                     egui::Slider::new(&mut settings.group, -1..=1),
                 );
             });
+            ui.checkbox(&mut settings.enable_light, "Enable light");
         });
 }


### PR DESCRIPTION
Implement map lighting parsing and rendering

- Parse LightMap structures using `byte`
- Integrate `LightMap` parsing into MapRenderer
- Expose an `enable_light` setting in the UI to toggle the lighting feature
- Tint map entities using parsed ambient light data from light.jar

---
*PR created automatically by Jules for task [321862720058415192](https://jules.google.com/task/321862720058415192) started by @jac3km4*